### PR TITLE
update bindgen to latest and fix broken build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ description = "rust-bindgen generated bindings for C++ tgaimage library"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.26"
+bindgen = "0.69"

--- a/build.rs
+++ b/build.rs
@@ -30,8 +30,8 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("tga/tgaimage.hpp")
-        .whitelisted_type("TGAImage")
-        .whitelisted_type("TGAColor")
+        .allowlist_type("TGAImage")
+        .allowlist_type("TGAColor")
         //.conservative_inline_namespaces() // see issue #789
         // Finish the builder and generate the bindings.
         .generate()


### PR DESCRIPTION
I was going through the tinyrenderer tutorial and this project seemed like a perfect drop-in for the author's TGA library in rust. The build would not work for me though. I updated the bindgen library to the latest version and fixed the build script.